### PR TITLE
Fix check_mode type references

### DIFF
--- a/manifests/check_mode.pp
+++ b/manifests/check_mode.pp
@@ -11,7 +11,7 @@
 #   mode => 755,
 # }
 #
-define check_mode($mode) {
+define vertica::check_mode($mode) {
   exec { "/bin/chmod -R ${mode} ${name}":
     onlyif => "test -e ${name}",
     path   => ['/usr/bin','/usr/sbin','/bin','/sbin'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -183,11 +183,11 @@ class vertica::config(
     require => Package['vertica'],
   }
 
-  check_mode { "/opt/vertica":
+  ::vertica::check_mode { "/opt/vertica":
     mode => 755,
     require => Package['vertica'],
   } ~>
-  check_mode { " /home/dbadmin/.ssh/id_rsa":
+  ::vertica::check_mode { " /home/dbadmin/.ssh/id_rsa":
     mode => 700,
   }
 


### PR DESCRIPTION
This needs to be fully qualified reference with the right name in the
definition to work on puppet 4.